### PR TITLE
fix formatting of author and contact in sidebar

### DIFF
--- a/_css/poole_hyde.css
+++ b/_css/poole_hyde.css
@@ -264,6 +264,21 @@ html {
     text-align: left;
   }
 }
+/* hide contact info, and author on the sidebar if screen is to small */
+@media only screen and (max-width: 768px) {
+	.sidebar-contact,
+	.sidebar-author
+       	{
+		display: none;
+	}
+}
+@media only screen and (max-height: 768px) {
+	.sidebar-contact,
+	.sidebar-author
+       	{
+		display: none;
+	}
+}
 
 /* Sidebar links */
 .sidebar a {
@@ -287,6 +302,7 @@ html {
   padding: 0.5%;
   line-height: 1.4;
 }
+
 
 .sidebar-contact a:hover { 
     transition: 0.2s;


### PR DESCRIPTION
Fixes the issue of contact and author overlapping other page elements.

Consider changing `max-height` to be dynamical or just adjust it to the expected sidebar size.