### PR TITLE
Fix event-descrb formatting

### DIFF
--- a/_css/poole_hyde.css
+++ b/_css/poole_hyde.css
@@ -426,16 +426,20 @@ a.sidebar-nav-item:focus {
   margin: 1rem;
 }
 
-.event-descrb p {
-  width: 70%;
-  float:left;
-  padding-right: 1%;
+@media (min-width: 1000px) {
+        .event-descrb {
+          	width: 100%;
+                display: flex;
+        }
+        .event-descrb p {
+          padding-right: 1%;
+        }
+
+        .event-descrb .fig {
+          flex-grow: 1;
+        }
 }
 
-.event-descrb .fig {
-  width: 30%;
-  float: left;
-}
 
 .fig {
 

--- a/_layout/sidebar.html
+++ b/_layout/sidebar.html
@@ -5,7 +5,7 @@
     </div>
     <nav class="sidebar-nav">
       <a class="sidebar-nav-item {{ispage index.html}}active{{end}}" href="/#kim_jesteśmy">Kim jesteśmy</a>
-      <a class="sidebar-nav-item {{ispage index.html}}active{{end}}" href="/#okole" style="font-size: 13px; text-indent: 12px;">O kole</a>
+      <a class="sidebar-nav-item {{ispage index.html}}active{{end}}" href="/#o_kole" style="font-size: 13px; text-indent: 12px;">O kole</a>
       <a class="sidebar-nav-item {{ispage index.html}}active{{end}}" href="/#zarząd" style="font-size: 13px; text-indent: 12px;">Zarząd</a>
       <a class="sidebar-nav-item {{ispage index.html}}active{{end}}" href="/#co_robimy">Co robimy</a>
       <a class="sidebar-nav-item {{ispage index.html}}active{{end}}" href="/#sempowisko" style="font-size: 13px; text-indent: 12px;">SeMPowisko</a>

--- a/index.html
+++ b/index.html
@@ -39,8 +39,9 @@
 
 <div class="content-section">
     <h2 id="co_robimy"><a href="#co_robimy" class="header-anchor">Co robimy</a></h2>
-    <div id="sempowisko" class="event-descrb">
+
       <h3><a href="#sempowisko" class="header-anchor">SeMPowisko</a></h3>
+    <div id="sempowisko" class="event-descrb">
       <p style="float: left;">
           Coroczna Interdyscyplinarna Studencka Konferencja „SeMPowisko” jest wydarzeniem o zasięgu (co najmniej) ogólnopolskim,
 	  organizowanym przez nasze Koło. 
@@ -54,9 +55,10 @@
           <p>autorka: Ksymena Poradzisz</p>
       </div>
     </div>
-    <div id="sempinaria_kołowe_seminaria" class="event-descrb">
+
         <h3><a href="#sempinaria_kołowe_seminaria" class="header-anchor">Sempinaria &#40;kołowe seminaria&#41;</a></h3>
-        <p>    
+    <div id="sempinaria_kołowe_seminaria" class="event-descrb">
+	<p>    
             Organizowane przez Członków Koła seminaria służą do dzielenia się tematami,
 	    niszowymi zagadnieniami i ciekawostkami, których nie sposób znaleźć w sylabusach przedmiotów. 
             Prócz możliwości wysłuchania barwnego referatu o tematyce z jednej z wielu dziedzin naukowych studiowanych przez Kołowiczów,
@@ -68,8 +70,9 @@
             <p>autorka: Ksymena Poradzisz</p>
         </div>
     </div>
-    <div id="wydarzenia_integracyjne" class="event-descrb">
+
         <h3><a href="#wydarzenia_integracyjne" class="header-anchor">Wydarzenia integracyjne</a></h3>
+    <div id="wydarzenia_integracyjne" class="event-descrb">
         <p>
             Mimo, że nauka i studia w życiu sempów zajmują większą cześć życia (minimalnie 81 000 min, czyli 60 ECTS-ów na rok),
 	    zawsze znajdzie się trochę czasu na spotkanie w bezpiecznej przystani pokoju H-1-03 na WFAIS. 
@@ -82,8 +85,9 @@
             <p>autorka: Ksymena Poradzisz</p>
         </div>
     </div>
-    <div id="szkoły" class="event-descrb">
+
         <h3><a href="#szkoły" class="header-anchor">Szkoły</a></h3>
+    <div id="szkoły" class="event-descrb">
         <p>
             Poza wydarzeniami na krakowskim kampusie, jeśli dopisze czas i pogoda,
 	    kilka razy do roku wybieramy się na kilkudniowe wyjazdy w góry (dalej nazywane szkołami).
@@ -97,6 +101,7 @@
             <p>autorka: Martyna Koprowska</p>
         </div>
 </div>
+
 </div>
 
 {{ insert page_foot.html }}

--- a/index.html
+++ b/index.html
@@ -11,9 +11,19 @@
     </div>
     <h3 id="o_kole"><a href="#okole" class="header-anchor">O kole</a></h3>
     <p>
-        Nasze koło powstało w 1998 roku, a od tamtego czasu zrzesza studentów wszystkich kierunków Międzywydziałowych Studiów Matematyczno-Przyrodniczych. Po wielu przejściach i migracjach wylądowaliśmy w pokoju H-1-0-3 na Wydziale Fizyki, Astronomii i Informatyki Stosowanej UJ, gdzie można nas spotkać do dziś. <br/> 
-        Cechą od zawsze wyróżniającą nasze koło jest jego interdyscyplinarność; w przeciwieństwie do większości tego typu organizacji studenckich, w H-1-0-3 spotkać można zarówno matematyków jak i informatyków, chemików, fizyków, biologów i geologów. Ta mnogość zainteresowań, choć czasem wprowadzająca lekkie zamieszanie, pozwala jednak na poszerzenie swojej wiedzy i ciekawości z dziedzin zupełnie odmiennych od studiowanej. Nasi kołowicze wygłaszają referaty równie różnorodne jak oni sami, a podczas dni naleśnika, dni pizzy, poseminaryjnych wyjść na piwo czy organizowanych kilka razy do roku wyjazdach w góry można się także poznać mniej akademicko, a bardziej koleżeńsko. <br/>
-        Dołączyć do koła można w dowolnym momencie od pierwszego dnia studiów, wystarczy odezwać się w dowolnym z podanych mediów lub odezwać bezpośrednio do skarbnika.
+        Nasze koło powstało w 1998 roku,
+	a od tamtego czasu zrzesza studentów wszystkich kierunków Międzywydziałowych Studiów Matematyczno-Przyrodniczych.
+	Po wielu przejściach i migracjach wylądowaliśmy w pokoju H-1-0-3 na Wydziale Fizyki,
+	Astronomii i Informatyki Stosowanej UJ, gdzie można nas spotkać do dziś. <br/> 
+        Cechą od zawsze wyróżniającą nasze koło jest jego interdyscyplinarność; w przeciwieństwie do większości tego typu organizacji studenckich,
+	w H-1-0-3 spotkać można zarówno matematyków jak i informatyków, chemików, fizyków, biologów i geologów.
+	Ta mnogość zainteresowań, choć czasem wprowadzająca lekkie zamieszanie,
+	pozwala jednak na poszerzenie swojej wiedzy i ciekawości z dziedzin zupełnie odmiennych od studiowanej.
+	Nasi kołowicze wygłaszają referaty równie różnorodne jak oni sami, a podczas dni naleśnika, dni pizzy,
+	poseminaryjnych wyjść na piwo czy organizowanych kilka razy do roku wyjazdach w góry można się także poznać mniej akademicko,
+	a bardziej koleżeńsko. <br/>
+        Dołączyć do koła można w dowolnym momencie od pierwszego dnia studiów,
+	wystarczy odezwać się w dowolnym z podanych mediów lub odezwać bezpośrednio do skarbnika.
     </p>
 <!--     <h3 id="historia_koła"><a href="#historia_koła" class="header-anchor">Krótka historia koła</a></h3>
     <p>historia here</p> -->
@@ -25,48 +35,19 @@
             Igor Piechowiak (skarbnik), Bartosz Żbik (zast. skarbnika) <br/> autorka: Ksymena Poradzisz
         </p>
     </div>
-<!--     <br/>
-    <div class="portrait" style="width: 25%;">
-    <img src="/assets/prezes.png" />
-    <p>Jakub Firlej <br/> Prezes</p>
-    </div>
-    <div class="portrait" style="width: 25%;">
-    <img src="/assets/skarbnik.png" />
-    <p> Igor Piechowiak <br/> Skarbnik </p>
-    </div>
-    <div class="portrait" style="width: 25%;">
-    <img src="/assets/zast_prezesa.png" />
-    <p> Aleksander Lenart <br/> Zastępca Prezesa </p>
-    </div>
-    <div class="portrait" style="width: 25%;">
-    <img src="/assets/zast_skarbnika.png" />
-    <p> Bartosz Żbik <br/> Zastępca Skarbnika </p>
-    </div> -->
-
-    <!-- <h3 id="komisja_rewizyjna"><a href="#komisja_rewizyjna" class="header-anchor">Komisja rewizyjna</a></h3> -->
-    
-    <!--  <br/>
-    <div class="portrait" style="width: 33%;">
-    <img src="/assets/komisarz_1.png" />
-    <p> Mateusz Winiarski </p>
-    </div>
-    <div class="portrait" style="width: 33%;">
-    <img src="/assets/komisarz_3.png" />
-    <p> Ksymena Poradzisz </p>
-    </div>
-    <div class="portrait" style="width: 33%;">
-    <img src="/assets/komisarz_2.png" />
-    <p> Marta Luterek </p>
-    </div> -->
 </div>
+
 <div class="content-section">
     <h2 id="co_robimy"><a href="#co_robimy" class="header-anchor">Co robimy</a></h2>
     <div id="sempowisko" class="event-descrb">
       <h3><a href="#sempowisko" class="header-anchor">SeMPowisko</a></h3>
       <p style="float: left;">
-          Coroczna Interdyscyplinarna Studencka Konferencja „SeMPowisko” jest wydarzeniem o zasięgu (co najmniej) ogólnopolskim, organizowanym przez nasze Koło. 
-          Głównym celem konferencji jest spotkanie studentów różnych nauk ścisłych i przyrodniczych oraz utworzenie przestrzeni do interdyscyplinarnej dyskusji.
-          Podczas konferencji posługujemy się językiem angielskim, co umożliwia lepsze przygotowanie na konferencje międzynarodowe oraz podszlifowanie swoich umiejętności językowych.
+          Coroczna Interdyscyplinarna Studencka Konferencja „SeMPowisko” jest wydarzeniem o zasięgu (co najmniej) ogólnopolskim,
+	  organizowanym przez nasze Koło. 
+          Głównym celem konferencji jest spotkanie studentów różnych nauk ścisłych i przyrodniczych oraz
+	  utworzenie przestrzeni do interdyscyplinarnej dyskusji.
+          Podczas konferencji posługujemy się językiem angielskim,
+	  co umożliwia lepsze przygotowanie na konferencje międzynarodowe oraz podszlifowanie swoich umiejętności językowych.
       </p>
       <div class="fig">
        <img src="/assets/sempowisko.jpg"/>
@@ -76,8 +57,10 @@
     <div id="sempinaria_kołowe_seminaria" class="event-descrb">
         <h3><a href="#sempinaria_kołowe_seminaria" class="header-anchor">Sempinaria &#40;kołowe seminaria&#41;</a></h3>
         <p>    
-            Organizowane przez Członków Koła seminaria służą do dzielenia się tematami, niszowymi zagadnieniami i ciekawostkami, których nie sposób znaleźć w sylabusach przedmiotów. 
-            Prócz możliwości wysłuchania barwnego referatu o tematyce z jednej z wielu dziedzin naukowych studiowanych przez Kołowiczów, spotkanie po godzinach zajęć w sali seminaryjnej pozwala poznać lepiej kolegów i koleżanki oraz uzyskać wgląd w to, co ich interesuje. 
+            Organizowane przez Członków Koła seminaria służą do dzielenia się tematami,
+	    niszowymi zagadnieniami i ciekawostkami, których nie sposób znaleźć w sylabusach przedmiotów. 
+            Prócz możliwości wysłuchania barwnego referatu o tematyce z jednej z wielu dziedzin naukowych studiowanych przez Kołowiczów,
+	    spotkanie po godzinach zajęć w sali seminaryjnej pozwala poznać lepiej kolegów i koleżanki oraz uzyskać wgląd w to, co ich interesuje. 
             Po wysłuchanym wykładzie proces poznawczy sempów jest najczęściej kontynuowany z tej mniej naukowej strony, w barze Tea Time.
         </p>
         <div class="fig">
@@ -88,8 +71,11 @@
     <div id="wydarzenia_integracyjne" class="event-descrb">
         <h3><a href="#wydarzenia_integracyjne" class="header-anchor">Wydarzenia integracyjne</a></h3>
         <p>
-            Mimo, że nauka i studia w życiu sempów zajmują większą cześć życia (minimalnie 81 000 min, czyli 60 ECTS-ów na rok), zawsze znajdzie się trochę czasu na spotkanie w bezpiecznej przystani pokoju H-1-03 na WFAIS. 
-            Można tam znaleźć kolegę, który pomoże w zdaniu przedmiotu, pudełko pizzy (z zawartością lub gdy szczęście nie dopisze bez), a w szczególnych przypadkach włączoną naleśnikarkę, przy której sam Prezes może przygotować strudzonym studentom ciepły obiad w postaci pysznego naleśnika.
+            Mimo, że nauka i studia w życiu sempów zajmują większą cześć życia (minimalnie 81 000 min, czyli 60 ECTS-ów na rok),
+	    zawsze znajdzie się trochę czasu na spotkanie w bezpiecznej przystani pokoju H-1-03 na WFAIS. 
+            Można tam znaleźć kolegę, który pomoże w zdaniu przedmiotu, pudełko pizzy
+	    (z zawartością lub gdy szczęście nie dopisze bez), a w szczególnych przypadkach włączoną naleśnikarkę,
+	    przy której sam Prezes może przygotować strudzonym studentom ciepły obiad w postaci pysznego naleśnika.
         </p>
         <div class="fig">
             <img src="/assets/planszowki.jpg" />
@@ -99,24 +85,18 @@
     <div id="szkoły" class="event-descrb">
         <h3><a href="#szkoły" class="header-anchor">Szkoły</a></h3>
         <p>
-            Poza wydarzeniami na krakowskim kampusie, jeśli dopisze czas i pogoda, kilka razy do roku wybieramy się na kilkudniowe wyjazdy w góry (dalej nazywane szkołami). Szkoły to wyjątkowe wydarzenia, podczas których poznajemy się, trochę wędrujemy (choć zawsze z uwzględnieniem i tych większych, i mnniejszych zapaleńców), podczas obowiązkowej sesji referatowej dzielimy swoimi zainteresowaniami (nie zawsze naukowymi!), słowem- miło spędzamy czas.
+            Poza wydarzeniami na krakowskim kampusie, jeśli dopisze czas i pogoda,
+	    kilka razy do roku wybieramy się na kilkudniowe wyjazdy w góry (dalej nazywane szkołami).
+	    Szkoły to wyjątkowe wydarzenia, podczas których poznajemy się,
+	    trochę wędrujemy (choć zawsze z uwzględnieniem i tych większych,
+	    i mnniejszych zapaleńców), podczas obowiązkowej sesji referatowej dzielimy się swoimi zainteresowaniami
+	    (nie zawsze naukowymi!), słowem- miło spędzamy czas.
         </p>
         <div class="fig">
             <img src="/assets/szkola_letnia_kolowicze.jpg" />
             <p>autorka: Martyna Koprowska</p>
         </div>
 </div>
-<!-- 
-<div class="content-section">
-    <h2 id="galeria"><a href="#galeria" class="header-anchor">Galeria</a></h2>
-    <h3 id="szkoły_jesienne"><a href="#szkoły_jesienne" class="header-anchor">Szkoły jesienne</a></h3>
-    <p>zdjęcia</p>
-    <h3 id="szkoły_letnie"><a href="#szkoły_letnie" class="header-anchor">Szkoły letnie</a></h3>
-    <img src="/assets/szkola_letnia_kolowicze.jpg"></img>
-    <h3 id="inne_eventy_fajne"><a href="#inne_eventy_fajne" class="header-anchor">Inne eventy fajne</a></h3>
-    <p>zdjęcia</p>
-
--->
 </div>
 
 {{ insert page_foot.html }}

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
         <img src="/assets/wigilia.png" style="width: 700px; "/>
         <p>Uśmiechnięci kołowicze, Wigilia 2022 <br/> autorka: Ksymena Poradzisz</p>
     </div>
-    <h3 id="o kole"><a href="#okole" class="header-anchor">O kole</a></h3>
+    <h3 id="o_kole"><a href="#okole" class="header-anchor">O kole</a></h3>
     <p>
         Nasze koło powstało w 1998 roku, a od tamtego czasu zrzesza studentów wszystkich kierunków Międzywydziałowych Studiów Matematyczno-Przyrodniczych. Po wielu przejściach i migracjach wylądowaliśmy w pokoju H-1-0-3 na Wydziale Fizyki, Astronomii i Informatyki Stosowanej UJ, gdzie można nas spotkać do dziś. <br/> 
         Cechą od zawsze wyróżniającą nasze koło jest jego interdyscyplinarność; w przeciwieństwie do większości tego typu organizacji studenckich, w H-1-0-3 spotkać można zarówno matematyków jak i informatyków, chemików, fizyków, biologów i geologów. Ta mnogość zainteresowań, choć czasem wprowadzająca lekkie zamieszanie, pozwala jednak na poszerzenie swojej wiedzy i ciekawości z dziedzin zupełnie odmiennych od studiowanej. Nasi kołowicze wygłaszają referaty równie różnorodne jak oni sami, a podczas dni naleśnika, dni pizzy, poseminaryjnych wyjść na piwo czy organizowanych kilka razy do roku wyjazdach w góry można się także poznać mniej akademicko, a bardziej koleżeńsko. <br/>


### PR DESCRIPTION
# Fix event-descrb formatting
Fixes the formatting of event-descrb.
I moved headers out of the container to make this method work.

Consider restriction the size of fig in some way, and adjusting the hard coded value of 1000px.

This pull request also fixes the reference to "O kole" section.